### PR TITLE
fix: u20 for Delta Clockstamp Ticks Since Last Event per spec

### DIFF
--- a/midi2/src/utility.rs
+++ b/midi2/src/utility.rs
@@ -97,7 +97,7 @@ mod timestamp {
 mod delta_clockstamp {
     use crate::detail::common_properties;
     use crate::utility;
-    use crate::ux::{u20, u4};
+    use crate::ux::u20;
     pub const STATUS: u8 = 0b0100;
     #[midi2_proc::generate_message(Via(crate::utility::Utility), FixedSize, MinSizeUmp(1))]
     struct DeltaClockstamp {
@@ -117,32 +117,19 @@ mod delta_clockstamp {
 
     impl<'a, B: crate::buffer::Ump> crate::detail::property::ReadProperty<'a, B> for DataProperty {
         fn read(buffer: &'a B) -> Self::Type {
-            use crate::detail::BitOps;
-            use core::ops::BitOr;
-            let bits: u20 = buffer.buffer()[0].nibble(3).into();
-            let bits = bits << 16;
-            bits.bitor(u20::new(buffer.buffer()[0].word(1) as u32))
+            u20::new(buffer.buffer()[0] & 0x000F_FFFF)
         }
         fn validate(_buffer: &B) -> Result<(), crate::error::InvalidData> {
             Ok(())
         }
     }
 
-    const UPPER_MASK: u20 = u20::new(0x000F_0000);
-    const LOWER_MASK: u20 = u20::new(0x0000_FFFF);
-
     impl<B: crate::buffer::Ump + crate::buffer::BufferMut> crate::detail::property::WriteProperty<B>
         for DataProperty
     {
         fn write(buffer: &mut B, value: Self::Type) {
-            use crate::detail::BitOps;
-            use core::ops::BitAnd;
-            let upper = value.bitand(UPPER_MASK) >> 16;
-            let upper: u4 = upper.try_into().unwrap();
-            let lower = value.bitand(LOWER_MASK);
-            let lower: u16 = lower.try_into().unwrap();
-            buffer.buffer_mut()[0].set_nibble(3, upper);
-            buffer.buffer_mut()[0].set_word(1, lower);
+            buffer.buffer_mut()[0] &= !0x000F_FFFF;
+            buffer.buffer_mut()[0] |= u32::from(value);
         }
         fn validate(_v: &Self::Type) -> Result<(), crate::error::InvalidData> {
             Ok(())
@@ -313,8 +300,8 @@ mod tests {
 
         let buffer: [u32; 4] = [0, 0, 0, 0];
         let mut dc = DeltaClockstamp::try_new_with_buffer(buffer).unwrap();
-        dc.set_time_data(u20::new(1_048_575));
-        assert_eq!(dc.time_data(), u20::new(0xF_FFFF));
+        dc.set_time_data(u20::new(0x1_2345));
+        assert_eq!(dc.time_data(), u20::new(0x1_2345));
     }
 
     #[test]


### PR DESCRIPTION
Overview:

1. Use 20 bits (was 16) for value of Delta Clockstamp (DC): Ticks Since Last Event
2. Keeps u16 for Delta Clockstamp Ticks Per Quarter Note (DCTPQ)

Details:

- Altered one occurrence of `#[property(utility::DataProperty)]` to have local definition within `mod delta_clockstamp` containing modifications for u20
- Used existing methods `nibble()` and `word()` to get/set parts of u20 value
- Followed patterns observed within the same .rs file
- Added test: `cargo test --features=utility`
- All passed: `cargo test --all-targets --all-features`
- Miri results are equivalent before vs after patch

Except from *Universal MIDI Packet (UMP) Format and MIDI 2.0 Protocol*
`M2-104-UM_v1-1-2_UMP_and_MIDI_2-0_Protocol_Specification.pdf`
p46

> 7.2.3.2 Delta Clockstamp (DC): Ticks Since Last Event
>
> The Delta Clockstamp message declares the time of all following messages
> which occur before the next Delta Clockstamp message. If this message is
> used outside of a MIDI Clip File (is sent on a UMP transport), most
> receivers will ignore this message.
>
> The timing of every message (other than Delta Clockstamps) in a MIDI Clip
> File is set by the most recent preceding Delta Clockstamp. Simultaneous
> events may share a single Delta Clockstamp. The order of simultaneous events
> can be critical. Therefore, events shall always be stored and transmitted in
> presentation order.
>
> `| mt=0 | res. | 0100 | ticks since last event|`
> `| .... | .... | .... | ....+................ |`
>
> Figure 34 Delta Clockstamp Message Format
>
> If no MIDI message has occurred during the previous 1,048,575 ticks, then
> the application which creates the MIDI Clip File shall insert a Delta
> Clockstamp followed by a NOOP message to restart the delta time count. Then
> the next Delta Clockstamp in the file declares the ticks since the previous
> NOOP message.
