### PR TITLE
fix: include trailing reserved bytes

### DIFF
--- a/midi2/src/channel_voice2/per_note_management.rs
+++ b/midi2/src/channel_voice2/per_note_management.rs
@@ -9,7 +9,7 @@ pub(crate) const STATUS: u8 = 0b1111;
 /// MIDI 2.0 Channel Voice Per Note Management Message
 ///
 /// See the [module docs](crate::channel_voice2) for more info.
-#[midi2_proc::generate_message(Via(crate::channel_voice2::ChannelVoice2), FixedSize, MinSizeUmp(1))]
+#[midi2_proc::generate_message(Via(crate::channel_voice2::ChannelVoice2), FixedSize, MinSizeUmp(2))]
 struct PerNoteManagement {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn note_number() {
         assert_eq!(
-            PerNoteManagement::try_from(&[0x4BF9_1C03][..])
+            PerNoteManagement::try_from(&[0x4BF9_1C03, 0x0][..])
                 .unwrap()
                 .note_number(),
             u7::new(0x1C),
@@ -58,14 +58,14 @@ mod tests {
 
     #[test]
     fn detach() {
-        assert!(PerNoteManagement::try_from(&[0x4BF9_1C03][..])
+        assert!(PerNoteManagement::try_from(&[0x4BF9_1C03, 0x0][..])
             .unwrap()
             .detach(),);
     }
 
     #[test]
     fn reset() {
-        assert!(PerNoteManagement::try_from(&[0x4BF9_1C03][..])
+        assert!(PerNoteManagement::try_from(&[0x4BF9_1C03, 0x0][..])
             .unwrap()
             .reset(),);
     }

--- a/midi2/src/flex_data.rs
+++ b/midi2/src/flex_data.rs
@@ -1224,7 +1224,7 @@ mod tests {
 
     #[test]
     fn try_from_set_tempo() {
-        let buffer = [0xD710_0000_u32, 0xF751_FE05];
+        let buffer = [0xD710_0000_u32, 0xF751_FE05, 0x0, 0x0];
         assert_eq!(
             FlexData::try_from(&buffer[..]),
             Ok(FlexData::SetTempo(
@@ -1235,8 +1235,9 @@ mod tests {
 
     #[test]
     fn read_bank() {
+        // Set Tempo
         assert_eq!(
-            FlexData::try_from(&[0xD710_0000_u32, 0xF751_FE05][..])
+            FlexData::try_from(&[0xD710_0000_u32, 0xF751_FE05, 0x0, 0x0][..])
                 .unwrap()
                 .bank(),
             Bank::SetupAndPerformance,

--- a/midi2/src/flex_data/set_key_signature.rs
+++ b/midi2/src/flex_data/set_key_signature.rs
@@ -9,7 +9,7 @@ const STATUS: u8 = 0x5;
 /// MIDI 2.0 Flex Data Set Key Signature Message
 ///
 /// See the [module docs](crate::flex_data) for more info.
-#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(2))]
+#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(4))]
 struct SetKeySignature {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn tonic() {
         assert_eq!(
-            SetKeySignature::try_from(&[0xD410_0005, 0x5400_0000][..])
+            SetKeySignature::try_from(&[0xD410_0005, 0x5400_0000, 0x0, 0x0][..])
                 .unwrap()
                 .tonic(),
             flex_data::tonic::Tonic::D,
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn sharps_flats() {
         assert_eq!(
-            SetKeySignature::try_from(&[0xD410_0005, 0x5400_0000][..])
+            SetKeySignature::try_from(&[0xD410_0005, 0x5400_0000, 0x0, 0x0][..])
                 .unwrap()
                 .sharps_flats(),
             SharpsFlats::Sharps(u3::new(5)),
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn sharps_flats_with_flats() {
         assert_eq!(
-            SetKeySignature::try_from(&[0xD410_0005, 0xB400_0000][..])
+            SetKeySignature::try_from(&[0xD410_0005, 0xB400_0000, 0x0, 0x0][..])
                 .unwrap()
                 .sharps_flats(),
             SharpsFlats::Flats(u3::new(5)),
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn sharps_flats_non_standard() {
         assert_eq!(
-            SetKeySignature::try_from(&[0xD410_0005, 0x8000_0000][..])
+            SetKeySignature::try_from(&[0xD410_0005, 0x8000_0000, 0x0, 0x0][..])
                 .unwrap()
                 .sharps_flats(),
             SharpsFlats::NonStandard,
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn channel() {
         assert_eq!(
-            SetKeySignature::try_from(&[0xD40D_0005, 0x8000_0000][..])
+            SetKeySignature::try_from(&[0xD40D_0005, 0x8000_0000, 0x0, 0x0][..])
                 .unwrap()
                 .optional_channel(),
             Some(u4::new(0xD)),
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn no_channel() {
         assert_eq!(
-            SetKeySignature::try_from(&[0xD410_0005, 0x8000_0000][..])
+            SetKeySignature::try_from(&[0xD410_0005, 0x8000_0000, 0x0, 0x0][..])
                 .unwrap()
                 .optional_channel(),
             None,

--- a/midi2/src/flex_data/set_metronome.rs
+++ b/midi2/src/flex_data/set_metronome.rs
@@ -8,7 +8,7 @@ const STATUS: u8 = 0x2;
 /// MIDI 2.0 Flex Data Set Metronome Message
 ///
 /// See the [module docs](crate::flex_data) for more info.
-#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(3))]
+#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(4))]
 struct SetMetronome {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn number_of_clocks_per_primary_click() {
         assert_eq!(
-            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000][..])
+            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000, 0x0][..])
                 .unwrap()
                 .number_of_clocks_per_primary_click(),
             0x9B,
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn bar_accent1() {
         assert_eq!(
-            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000][..])
+            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000, 0x0][..])
                 .unwrap()
                 .bar_accent1(),
             0x4A,
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn bar_accent2() {
         assert_eq!(
-            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000][..])
+            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000, 0x0][..])
                 .unwrap()
                 .bar_accent2(),
             0xFE,
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn bar_accent3() {
         assert_eq!(
-            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000][..])
+            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000, 0x0][..])
                 .unwrap()
                 .bar_accent3(),
             0x56,
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn number_of_subdivision_clicks1() {
         assert_eq!(
-            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000][..])
+            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000, 0x0][..])
                 .unwrap()
                 .number_of_subdivision_clicks1(),
             0xB8,
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn number_of_subdivision_clicks2() {
         assert_eq!(
-            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000][..])
+            SetMetronome::try_from(&[0xD110_0002, 0x9B4A_FE56, 0xB81B_0000, 0x0][..])
                 .unwrap()
                 .number_of_subdivision_clicks2(),
             0x1B,

--- a/midi2/src/flex_data/set_tempo.rs
+++ b/midi2/src/flex_data/set_tempo.rs
@@ -8,7 +8,7 @@ const STATUS: u8 = 0x0;
 /// MIDI 2.0 Flex Data Set Tempo Message
 ///
 /// See the [module docs](crate::flex_data) for more info.
-#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(2))]
+#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(4))]
 struct SetTempo {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -48,7 +48,7 @@ mod tests {
     #[test]
     fn number_of_10_nanosecond_units_per_quarter_note() {
         assert_eq!(
-            SetTempo::try_from(&[0xD710_0000, 0xF751_FE05,][..])
+            SetTempo::try_from(&[0xD710_0000, 0xF751_FE05, 0x0, 0x0][..])
                 .unwrap()
                 .number_of_10_nanosecond_units_per_quarter_note(),
             0xF751FE05,

--- a/midi2/src/flex_data/set_time_signature.rs
+++ b/midi2/src/flex_data/set_time_signature.rs
@@ -8,7 +8,7 @@ const STATUS: u8 = 0x1;
 /// MIDI 2.0 Flex Data Set Time Signature Message
 ///
 /// See the [module docs](crate::flex_data) for more info.
-#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(2))]
+#[midi2_proc::generate_message(Via(crate::flex_data::FlexData), FixedSize, MinSizeUmp(4))]
 struct SetTimeSignature {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -63,7 +63,7 @@ mod tests {
     #[test]
     fn numerator() {
         assert_eq!(
-            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00,][..])
+            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00, 0x0, 0x0][..])
                 .unwrap()
                 .numerator(),
             0xCD,
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn denominator() {
         assert_eq!(
-            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00,][..])
+            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00, 0x0, 0x0][..])
                 .unwrap()
                 .denominator(),
             0x90,
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn number_of_32nd_notes() {
         assert_eq!(
-            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00,][..])
+            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00, 0x0, 0x0][..])
                 .unwrap()
                 .number_of_32nd_notes(),
             0x7E,
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn bank() {
         assert_eq!(
-            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00,][..])
+            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00, 0x0, 0x0][..])
                 .unwrap()
                 .bank(),
             flex_data::Bank::SetupAndPerformance,
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn status() {
         assert_eq!(
-            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00,][..])
+            SetTimeSignature::try_from(&[0xDA10_0001, 0xCD90_7E00, 0x0, 0x0][..])
                 .unwrap()
                 .status(),
             STATUS,

--- a/midi2/src/ump_stream/end_of_clip.rs
+++ b/midi2/src/ump_stream/end_of_clip.rs
@@ -2,7 +2,7 @@ use crate::{detail::common_properties, ump_stream, ump_stream::UMP_MESSAGE_TYPE}
 
 pub(crate) const STATUS: u16 = 0x21;
 
-#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(1))]
+#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(4))]
 struct EndOfClip {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn from_data() {
         assert_eq!(
-            EndOfClip::try_from(&[0xF021_0000][..]),
-            Ok(EndOfClip(&[0xF021_0000][..]))
+            EndOfClip::try_from(&[0xF021_0000, 0x0, 0x0, 0x0][..]),
+            Ok(EndOfClip(&[0xF021_0000, 0x0, 0x0, 0x0][..]))
         );
     }
 }

--- a/midi2/src/ump_stream/endpoint_discovery.rs
+++ b/midi2/src/ump_stream/endpoint_discovery.rs
@@ -6,7 +6,7 @@ use crate::{
 
 pub(crate) const STATUS: u16 = 0x0;
 
-#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(2))]
+#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(4))]
 struct EndpointDiscovery {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn ump_version_major() {
         assert_eq!(
-            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F][..])
+            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F, 0x0, 0x0][..])
                 .unwrap()
                 .ump_version_major(),
             0x1,
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn ump_version_minor() {
         assert_eq!(
-            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F][..])
+            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F, 0x0, 0x0][..])
                 .unwrap()
                 .ump_version_minor(),
             0x1,
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn request_endpoint_info() {
         assert_eq!(
-            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F][..])
+            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F, 0x0, 0x0][..])
                 .unwrap()
                 .request_endpoint_info(),
             true,
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn request_device_identity() {
         assert_eq!(
-            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F][..])
+            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F, 0x0, 0x0][..])
                 .unwrap()
                 .request_device_identity(),
             true,
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn request_endpoint_name() {
         assert_eq!(
-            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F][..])
+            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F, 0x0, 0x0][..])
                 .unwrap()
                 .request_endpoint_name(),
             true,
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn request_product_instance_id() {
         assert_eq!(
-            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F][..])
+            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F, 0x0, 0x0][..])
                 .unwrap()
                 .request_product_instance_id(),
             true,
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn request_stream_configuration() {
         assert_eq!(
-            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F][..])
+            EndpointDiscovery::try_from(&[0xF000_0101, 0x0000_001F, 0x0, 0x0][..])
                 .unwrap()
                 .request_stream_configuration(),
             true,

--- a/midi2/src/ump_stream/endpoint_info.rs
+++ b/midi2/src/ump_stream/endpoint_info.rs
@@ -7,7 +7,7 @@ use crate::{
 
 pub(crate) const STATUS: u16 = 0x01;
 
-#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(2))]
+#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(4))]
 struct EndpointInfo {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -64,9 +64,16 @@ mod tests {
     #[test]
     fn ump_version_major() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .ump_version_major(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .ump_version_major(),
             0x1,
         );
     }
@@ -74,9 +81,16 @@ mod tests {
     #[test]
     fn ump_version_minor() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .ump_version_minor(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .ump_version_minor(),
             0x1,
         );
     }
@@ -84,9 +98,16 @@ mod tests {
     #[test]
     fn static_function_blocks() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .static_function_blocks(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .static_function_blocks(),
             true,
         );
     }
@@ -94,9 +115,16 @@ mod tests {
     #[test]
     fn number_of_function_blocks() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .number_of_function_blocks(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .number_of_function_blocks(),
             u7::new(0x20),
         );
     }
@@ -104,9 +132,16 @@ mod tests {
     #[test]
     fn supports_midi2_protocol() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .supports_midi2_protocol(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .supports_midi2_protocol(),
             true,
         );
     }
@@ -114,9 +149,16 @@ mod tests {
     #[test]
     fn supports_midi1_protocol() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .supports_midi1_protocol(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .supports_midi1_protocol(),
             true,
         );
     }
@@ -124,9 +166,16 @@ mod tests {
     #[test]
     fn supports_sending_jr_timestamps() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .supports_sending_jr_timestamps(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .supports_sending_jr_timestamps(),
             true,
         );
     }
@@ -134,9 +183,16 @@ mod tests {
     #[test]
     fn supports_receiving_jr_timestamps() {
         assert_eq!(
-            EndpointInfo::try_from(&[0xF001_0101, 0b1010_0000_0000_0000_0000_0011_0000_0011,][..])
-                .unwrap()
-                .supports_receiving_jr_timestamps(),
+            EndpointInfo::try_from(
+                &[
+                    0xF001_0101,
+                    0b1010_0000_0000_0000_0000_0011_0000_0011,
+                    0x0,
+                    0x0
+                ][..]
+            )
+            .unwrap()
+            .supports_receiving_jr_timestamps(),
             true,
         );
     }

--- a/midi2/src/ump_stream/function_block_info.rs
+++ b/midi2/src/ump_stream/function_block_info.rs
@@ -7,7 +7,7 @@ use crate::{
 
 pub(crate) const STATUS: u16 = 0x11;
 
-#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(2))]
+#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(4))]
 struct FunctionBlockInfo {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn active() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .active(),
             true
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn function_block_number() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .function_block_number(),
             u7::new(0x11),
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn first_group() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .first_group(),
             u4::new(0xD),
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn number_of_groups_spanned() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .number_of_groups_spanned(),
             0x8,
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn midi_ci_version() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .midi_ci_version(),
             0x1,
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn max_number_of_midi_ci_streams() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .max_number_of_midi_ci_streams(),
             0x20,
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn ui_hint() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .ui_hint(),
             UiHint::SenderReciever,
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn midi1_port() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .midi1_port(),
             Some(Midi1Port::DontRestrictBandwidth),
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn direction() {
         assert_eq!(
-            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120][..])
+            FunctionBlockInfo::try_from(&[0xF011_9136, 0x0D08_0120, 0x0, 0x0][..])
                 .unwrap()
                 .direction(),
             Direction::Output,

--- a/midi2/src/ump_stream/start_of_clip.rs
+++ b/midi2/src/ump_stream/start_of_clip.rs
@@ -2,7 +2,7 @@ use crate::{detail::common_properties, ump_stream, ump_stream::UMP_MESSAGE_TYPE}
 
 pub(crate) const STATUS: u16 = 0x20;
 
-#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(1))]
+#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(4))]
 struct StartOfClip {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn from_data() {
         assert_eq!(
-            StartOfClip::try_from(&[0xF020_0000][..]),
-            Ok(StartOfClip(&[0xF020_0000][..])),
+            StartOfClip::try_from(&[0xF020_0000, 0x0, 0x0, 0x0][..]),
+            Ok(StartOfClip(&[0xF020_0000, 0x0, 0x0, 0x0][..])),
         );
     }
 }

--- a/midi2/src/ump_stream/stream_configuration_notification.rs
+++ b/midi2/src/ump_stream/stream_configuration_notification.rs
@@ -6,7 +6,7 @@ use crate::{
 
 pub(crate) const STATUS: u16 = 0x6;
 
-#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(1))]
+#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(4))]
 struct StreamConfigurationNotification {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn protocol() {
         assert_eq!(
-            StreamConfigurationNotification::try_from(&[0xF006_0203][..])
+            StreamConfigurationNotification::try_from(&[0xF006_0203, 0x0, 0x0, 0x0][..])
                 .unwrap()
                 .protocol(),
             0x2
@@ -52,7 +52,7 @@ mod tests {
     #[test]
     fn receive_jr_timestamps() {
         assert_eq!(
-            StreamConfigurationNotification::try_from(&[0xF006_0203][..])
+            StreamConfigurationNotification::try_from(&[0xF006_0203, 0x0, 0x0, 0x0][..])
                 .unwrap()
                 .receive_jr_timestamps(),
             true
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn send_jr_timestamps() {
         assert_eq!(
-            StreamConfigurationNotification::try_from(&[0xF006_0203][..])
+            StreamConfigurationNotification::try_from(&[0xF006_0203, 0x0, 0x0, 0x0][..])
                 .unwrap()
                 .send_jr_timestamps(),
             true

--- a/midi2/src/ump_stream/stream_configuration_request.rs
+++ b/midi2/src/ump_stream/stream_configuration_request.rs
@@ -6,7 +6,7 @@ use crate::{
 
 pub(crate) const STATUS: u16 = 0x5;
 
-#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(1))]
+#[midi2_proc::generate_message(Via(ump_stream::UmpStream), FixedSize, MinSizeUmp(4))]
 struct StreamConfigurationRequest {
     #[property(common_properties::UmpMessageTypeProperty<UMP_MESSAGE_TYPE>)]
     ump_type: (),
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn protocol() {
         assert_eq!(
-            StreamConfigurationRequest::try_from(&[0xF005_0203][..])
+            StreamConfigurationRequest::try_from(&[0xF005_0203, 0x0, 0x0, 0x0][..])
                 .unwrap()
                 .protocol(),
             0x2
@@ -52,7 +52,7 @@ mod tests {
     #[test]
     fn receive_jr_timestamps() {
         assert_eq!(
-            StreamConfigurationRequest::try_from(&[0xF005_0203][..])
+            StreamConfigurationRequest::try_from(&[0xF005_0203, 0x0, 0x0, 0x0][..])
                 .unwrap()
                 .receive_jr_timestamps(),
             true
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn send_jr_timestamps() {
         assert_eq!(
-            StreamConfigurationRequest::try_from(&[0xF005_0203][..])
+            StreamConfigurationRequest::try_from(&[0xF005_0203, 0x0, 0x0, 0x0][..])
                 .unwrap()
                 .send_jr_timestamps(),
             true


### PR DESCRIPTION
The MIDI 2.0 spec documents could be better about total required number of bytes for each type of message, so it's too easy to miss where 128 bits are required.

- Trailing portions of a MIDI message that are specified as "Reserved" must be included even when all zeros
  + e.g., Set Tempo looks like it should fit within 64 bits but requires 128 bits
- Relevant tests are revised for appending appropriate number of zeroed bytes
- All passed: `cargo test --all-targets --all-features`
- Appears correct when viewed within [MIDI 2.0 Workbench](https://github.com/midi2-dev/MIDI2.0Workbench)'s SMF2 window
  + Albeit, haven't generated a `.midi2` file with *everything* that has changed

Details:

- References to individual sections below are from `M2-104-UM`
  + *Universal MIDI Packet (UMP) Format and MIDI 2.0 Protocol* spec
- For a summary with visuals, see "Appendix F: All Defined UMP Formats" and "Appendix G: All Defined Messages"
  + Table 27 4-Byte UMP Formats for Message Type 0x1: System Common & System Real Time
  + Table 32 128 bit UMP Formats for Message Type 0xD: Flex Data Messages
  + Table 33 128 bit UMP Formats for Message Type 0xF: UMP Stream Messages
- However, one table obscures the Reserved portion of some messages
  + Table 34 All Defined Message Formats (in 5 parts)
  + Beware of its rightmost column "Bytes 9-16 (64 bits)" because of portrait to landscape page rotation
- section 7.1 UMP Stream Messages
  + > UMP Stream Messages are addressed to the UMP Endpoint, without a Group 
      > or Channel assignment.  All UMP Stream Messages are 128-bit messages [...]
- section 7.4.5 MIDI 2.0 Per-Note Management Message
  + e.g., total bits must be extracted from their diagram
  + > `| mt=4 | group| 1111 | ch.  | r+note# | flags  | D | S |`
     > `| .... | .... | .... | .... | ....... | ...... | . | . |`
     > `|                       reserved                       |`
- section 7.5.1 Flex Data Messages General Format
  + See first bullet point:
  + > A Format field is used to optionally allow a message to have a variable size data, in multiples of 128 bits.
- Similar:
  + 7.5.3 Set Tempo Message
  + 7.5.4 Set Time Signature Message
  + 7.5.5 Set Metronome Message
  + 7.5.6 Example Set Metronome Messages
  + 7.5.7 Set Key Signature Message
- Screenshots from midi2.dev's MIDI 2.0 Workbench SMF2 window: (see below)
  + That's how this issue was discovered
  + `MIDI 2.0 Workbench - zeroed reserved bytes.png` (with patch)
  + `MIDI 2.0 Workbench - malformed midi2 file.png`
  + Reserved bytes that should be zero engulfed other messages
  + Malformed at byte offset 20 and 36, thus SMF2 window unable to identify Header / Sequence boundary
  + Images via patched Workbench; see multiple PRs there

TODO — possibly related:

- Table 27 4-Byte UMP Formats for Message Type 0x1: System Common & System Real Time
  + e.g., Tune Request uses 2 bytes with an additional 2 bytes reserved
  + `midi2/src/system_common.rs` mentions `MinSizeUmp(1), MinSizeBytes(2)`
  + That parameter for 2 bytes might need to become 4 but needs confirmation

```rust
#[midi2_proc::generate_message(
    Via(system_common::SystemCommon),
    FixedSize,
    MinSizeUmp(1),
    MinSizeBytes(2)
)]
struct TuneRequest { /* ... */ }
```

<img width="1026" height="827" alt="MIDI 2 0 Workbench - zeroed reserved bytes" src="https://github.com/user-attachments/assets/c30afc5e-9fa6-4809-be51-9199fdbd2381" />

<img width="1026" height="827" alt="MIDI 2 0 Workbench - malformed midi2 file" src="https://github.com/user-attachments/assets/62eb8974-02d1-4654-83dc-e7b3ddd8162c" />